### PR TITLE
Add helper to restore QNN context and graph from binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# QNN_backend
+# QNN Backend Context Loader
+
+This repository provides a minimal helper for reconstructing a QNN backend context and graph from a serialized context binary that was exported from an ExecuTorch `.pte` bundle. The helper mirrors the flow used in `executorch/examples/qualcomm/oss_scripts/llama/qnn_llama_runner.cpp`, but is condensed so that it can be integrated into other frameworks or Android test harnesses.
+
+## Building
+
+The code is standard C++17 and only depends on the QNN SDK headers/libraries and `dlopen`. To build for Android (aarch64), cross-compile the sources with the Android NDK and link against the QNN backend shared objects (`libQnnHtp.so`, etc.).
+
+```bash
+# Example: building a standalone binary with the Android NDK toolchain
+ANDROID_NDK_HOME=/path/to/android/ndk \
+$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang++ \
+    -Iinclude \
+    examples/qnn_context_main.cpp src/qnn_context_loader.cpp \
+    -ldl -o qnn_context_main
+```
+
+Push the resulting binary to the Android device and invoke it under `adb shell`:
+
+```bash
+adb push qnn_context_main /data/local/tmp/
+adb push your_context.bin /data/local/tmp/
+adb push libQnnHtp.so /data/local/tmp/
+adb shell "cd /data/local/tmp && LD_LIBRARY_PATH=. ./qnn_context_main ./libQnnHtp.so ./your_context.bin"
+```
+
+## API Overview
+
+* `qnn::BackendLoader` wraps `dlopen`/`dlsym` and instantiates a QNN backend using the exported interface entry point (`QnnInterface`).
+* `qnn::load_context_and_graph` reads a serialized context binary, deserializes it via `contextCreateFromBinary`, and materializes a graph handle via `graphCreateFromContext`.
+* `examples/qnn_context_main.cpp` demonstrates how to wire these utilities into a simple CLI suitable for iterative testing on Android devices.
+
+When linking against the real QNN SDK, include the appropriate headers **before** `qnn_context_loader.h` to ensure that the full `QnnInterface` definition (with the actual function pointer names) is visible to the compiler.
+

--- a/examples/qnn_context_main.cpp
+++ b/examples/qnn_context_main.cpp
@@ -1,0 +1,29 @@
+#include "qnn_context_loader.h"
+
+#include <iostream>
+
+int main(int argc, char** argv) {
+  if (argc < 3) {
+    std::cerr << "Usage: " << argv[0] << " <path/to/libQnnHtp.so> <path/to/context.bin> [graph_name]\n";
+    return 1;
+  }
+
+  try {
+    const std::string backend_path = argv[1];
+    const std::string context_binary = argv[2];
+    const std::string graph_name = argc > 3 ? argv[3] : "graph_0";
+
+    auto result = qnn::load_context_and_graph(backend_path, context_binary, graph_name);
+
+    std::cout << "Successfully instantiated QNN context and graph." << std::endl;
+    std::cout << "  Backend handle: " << result.backend << std::endl;
+    std::cout << "  Context handle: " << result.context << std::endl;
+    std::cout << "  Graph handle:   " << result.graph << std::endl;
+  } catch (const std::exception& ex) {
+    std::cerr << "QNN initialization failed: " << ex.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
+}
+

--- a/include/qnn_context_loader.h
+++ b/include/qnn_context_loader.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Forward declarations for QNN types to avoid needing the actual headers during host-side
+// development. When building against the Qualcomm Neural Network SDK, include
+// the appropriate QNN headers *before* this file or define the full types here.
+struct QnnInterface;
+typedef void* QnnBackend_Handle_t;
+typedef void* QnnContext_Handle_t;
+typedef void* QnnGraph_Handle_t;
+typedef int Qnn_ErrorHandle_t;
+
+namespace qnn {
+
+//! Simple RAII wrapper around dlopen/dlsym for loading the QNN backend shared library.
+class BackendLoader {
+ public:
+  BackendLoader() = default;
+  BackendLoader(const BackendLoader&) = delete;
+  BackendLoader& operator=(const BackendLoader&) = delete;
+  BackendLoader(BackendLoader&&) noexcept;
+  BackendLoader& operator=(BackendLoader&&) noexcept;
+  ~BackendLoader();
+
+  //! Loads the backend shared object and resolves the interface entry point.
+  void load_backend(std::string_view backend_path, std::string_view interface_symbol = "QnnInterface");
+
+  //! Returns the resolved QNN interface pointer.
+  const QnnInterface* interface() const { return interface_; }
+
+  //! Returns the backend handle created through the interface.
+  QnnBackend_Handle_t backend() const { return backend_handle_; }
+
+ private:
+  void* handle_ = nullptr;
+  const QnnInterface* interface_ = nullptr;
+  QnnBackend_Handle_t backend_handle_ = nullptr;
+};
+
+//! Helper that materializes a QNN context and a graph from a serialized context binary.
+struct ContextAndGraph {
+  BackendLoader loader;
+  const QnnInterface* interface = nullptr;
+  QnnBackend_Handle_t backend = nullptr;
+  QnnContext_Handle_t context = nullptr;
+  QnnGraph_Handle_t graph = nullptr;
+};
+
+//! Loads a serialized QNN context binary from disk and instantiates a context and graph.
+ContextAndGraph load_context_and_graph(std::string_view backend_path,
+                                       std::string_view context_binary_path,
+                                       std::string_view graph_name = "graph_0");
+
+//! Utility to read a binary file into memory.
+std::vector<uint8_t> read_file(std::string_view path);
+
+//! Convenience wrapper that throws on non-success QNN status values.
+void check_qnn_status(Qnn_ErrorHandle_t status, std::string_view message);
+
+}  // namespace qnn
+

--- a/src/qnn_context_loader.cpp
+++ b/src/qnn_context_loader.cpp
@@ -1,0 +1,139 @@
+#include "qnn_context_loader.h"
+
+#include <dlfcn.h>
+
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// The real QNN headers define a struct full of function pointers. We only forward declare it
+// in the header to keep this sample self-contained. When integrating into your build, include
+// <QnnInterface.h> (or the appropriate backend interface header) *before* our header so that the
+// compiler sees the full definition.
+struct QnnInterface {
+  // Minimal subset of the entry points we use. If your SDK exposes differently named symbols,
+  // update these pointers to match the actual API.
+  Qnn_ErrorHandle_t (*backendCreate)(QnnBackend_Handle_t* backend_handle);
+  Qnn_ErrorHandle_t (*backendFree)(QnnBackend_Handle_t backend_handle);
+  Qnn_ErrorHandle_t (*contextCreateFromBinary)(QnnBackend_Handle_t backend,
+                                               const uint8_t* binary,
+                                               size_t binary_size,
+                                               QnnContext_Handle_t* context_handle);
+  Qnn_ErrorHandle_t (*contextFree)(QnnContext_Handle_t context_handle);
+  Qnn_ErrorHandle_t (*graphCreateFromContext)(QnnContext_Handle_t context,
+                                              const char* graph_name,
+                                              QnnGraph_Handle_t* graph_handle);
+  Qnn_ErrorHandle_t (*graphFree)(QnnGraph_Handle_t graph_handle);
+};
+
+namespace qnn {
+
+BackendLoader::BackendLoader(BackendLoader&& other) noexcept {
+  *this = std::move(other);
+}
+
+BackendLoader& BackendLoader::operator=(BackendLoader&& other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  if (interface_ && backend_handle_) {
+    interface_->backendFree(backend_handle_);
+  }
+  if (handle_) {
+    dlclose(handle_);
+  }
+
+  handle_ = other.handle_;
+  interface_ = other.interface_;
+  backend_handle_ = other.backend_handle_;
+
+  other.handle_ = nullptr;
+  other.interface_ = nullptr;
+  other.backend_handle_ = nullptr;
+  return *this;
+}
+
+BackendLoader::~BackendLoader() {
+  if (interface_ && backend_handle_) {
+    interface_->backendFree(backend_handle_);
+    backend_handle_ = nullptr;
+  }
+
+  if (handle_) {
+    dlclose(handle_);
+    handle_ = nullptr;
+  }
+}
+
+void BackendLoader::load_backend(std::string_view backend_path, std::string_view interface_symbol) {
+  if (backend_handle_) {
+    return;  // already loaded
+  }
+
+  handle_ = dlopen(std::string(backend_path).c_str(), RTLD_NOW | RTLD_LOCAL);
+  if (!handle_) {
+    throw std::runtime_error("Failed to dlopen backend: " + std::string(dlerror()));
+  }
+
+  using InterfaceGetter = const QnnInterface* (*)();
+  auto* getter = reinterpret_cast<InterfaceGetter>(dlsym(handle_, std::string(interface_symbol).c_str()));
+  if (!getter) {
+    throw std::runtime_error("Unable to resolve interface symbol " + std::string(interface_symbol));
+  }
+
+  interface_ = getter();
+  if (!interface_ || !interface_->backendCreate) {
+    throw std::runtime_error("QNN interface is missing mandatory entry points");
+  }
+
+  check_qnn_status(interface_->backendCreate(&backend_handle_), "backendCreate failed");
+}
+
+std::vector<uint8_t> read_file(std::string_view path) {
+  std::ifstream in(std::string(path), std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("Unable to open file: " + std::string(path));
+  }
+
+  std::vector<uint8_t> data((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  if (data.empty()) {
+    throw std::runtime_error("File is empty: " + std::string(path));
+  }
+  return data;
+}
+
+void check_qnn_status(Qnn_ErrorHandle_t status, std::string_view message) {
+  if (status != 0) {
+    throw std::runtime_error(std::string(message) + ": status=" + std::to_string(status));
+  }
+}
+
+ContextAndGraph load_context_and_graph(std::string_view backend_path,
+                                       std::string_view context_binary_path,
+                                       std::string_view graph_name) {
+  ContextAndGraph result;
+  result.loader.load_backend(backend_path);
+  result.interface = result.loader.interface();
+  result.backend = result.loader.backend();
+
+  std::vector<uint8_t> context_binary = read_file(context_binary_path);
+
+  check_qnn_status(result.interface->contextCreateFromBinary(result.backend,
+                                                             context_binary.data(),
+                                                             context_binary.size(),
+                                                             &result.context),
+                   "contextCreateFromBinary failed");
+
+  check_qnn_status(result.interface->graphCreateFromContext(result.context,
+                                                            std::string(graph_name).c_str(),
+                                                            &result.graph),
+                   "graphCreateFromContext failed");
+
+  return result;
+}
+
+}  // namespace qnn
+


### PR DESCRIPTION
## Summary
- add reusable loader that opens a QNN backend via dlopen and instantiates it through the exported interface
- deserialize ExecuTorch-extracted context binaries into QNN contexts and graphs
- provide a simple CLI example and build notes for Android adb workflows

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d74e7b5fdc8333bea090f6964e2d6f